### PR TITLE
Improve how Unity Package Manager displays the packages

### DIFF
--- a/src/UnityNuGet/RegistryCache.cs
+++ b/src/UnityNuGet/RegistryCache.cs
@@ -353,8 +353,8 @@ namespace UnityNuGet
                         Version = npmCurrentVersion,
                         Name = npmPackageId,
                         Description = packageMeta.Description,
-                        Author = npmPackageInfo.Author,
-                        DisplayName = packageMeta.Title + _packageNameNuGetPostFix
+                        Author = "NuGet",
+                        DisplayName = packageMeta.Title + $"({npmPackageInfo.Author})"
                     };
                     npmVersion.Distribution.Tarball = new Uri(_rootHttpUri, $"{npmPackage.Id}/-/{GetUnityPackageFileName(packageIdentity, npmVersion)}");
                     npmVersion.Unity = _minimumUnityVersion;


### PR DESCRIPTION
This will allow UPM to group the packages under Packages - NuGet and add the other to the name, like Unity does with normal packages

