### PR TITLE
Add physics world loader to registry

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -8,9 +8,10 @@
 
   <packageSourceMapping>
     <packageSource key="MainPrivateFeed">
-      <package pattern="TrackMan.SharedCalculator" />
+      <package pattern="PhysicsWorldLoader" />
       <package pattern="Primitively.Trackman" />
       <package pattern="Primitively.Trackman.Abstractions" />
+      <package pattern="TrackMan.SharedCalculator" />
     </packageSource>
     <packageSource key="PrivateFeed">
       <package pattern="Trackman.*" />

--- a/registry.json
+++ b/registry.json
@@ -33,6 +33,10 @@
     "version": "1.1.0",
     "analyzer": true
   },
+  "Google.FlatBuffers": {
+    "listed": true,
+    "version": "22.9.24"
+  },
   "I18Next.Net": {
     "listed": true,
     "version": "[0.7.2,)"
@@ -210,6 +214,10 @@
   "OpenTracing": {
     "listed": false,
     "version": "0.12.0"
+  },
+  "PhysicsWorldLoader": {
+    "listed": true,
+    "version": "[0.1.2,)"
   },
   "Poly2Tri.NetStandard2": {
     "listed": true,


### PR DESCRIPTION
Adds `PhysicsWorldLoader` and its `Google.FlatBuffers` dependency to the curated registry.

> The NuGet package needs to respect a few constraints in order to be listed in the curated list:
> - [x] Add a link to the NuGet package: [PhysicsWorldLoader 0.1.2](https://dev.azure.com/trackman/Tracking/_artifacts/feed/Main/NuGet/PhysicsWorldLoader/overview/0.1.2)
> - [x] It must have non-preview versions
> - [ ] It must provide .NETStandard2.0 assemblies as part of its package
>   - `PhysicsWorldLoader` targets .NET Standard 2.1 as it depends on shared calculator, which is .NET Standard 2.1. TrackmanGolf is also using .NET Standard 2.1
> - [ ] The lowest version added must be the lowest .NETStandard2.0 version available
>   - Not applicable as we are using .NET Standard 2.1
> - [x] The package has been tested with the Unity editor
>   - Tested with Unity 6000.3.15f1 on Linux x64, including loading an exported physics world and raycasting against it.
> - [ ] The package has been tested with a Unity standalone player
>   - Waiting for the packages from the UnityNuGet server. It will then be tested through the multi-platform Unity pipeline. This PR only adds packages, no modification, so nothing existing will break
> - [x] All package dependencies with .NETStandard 2.0 targets have been added to the PR
>   - `Google.FlatBuffers` is included in the registry starting at `22.9.24`; PhysicsWorldLoader uses `25.2.10`.
>   - `TrackMan.SharedCalculator` is supplied by the consuming Unity project and is already present in the registry.